### PR TITLE
Removing redundancy stripping from ZFA

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -35,7 +35,7 @@ REPORT_FAIL_ON =            None
 REPORT_LABEL =              -l true
 REPORT_PROFILE_OPTS =       
 OBO_FORMAT_OPTIONS =        
-SPARQL_VALIDATION_CHECKS =   equivalent-classes owldef-self-reference iri-range
+SPARQL_VALIDATION_CHECKS =   equivalent-classes owldef-self-reference
 SPARQL_EXPORTS =             basic-report class-count-by-prefix edges xrefs obsoletes synonyms
 ODK_VERSION_MAKEFILE =      v1.2.32
 
@@ -48,7 +48,7 @@ ONTOLOGYTERMS =             $(TMPDIR)/ontologyterms.txt
 
 FORMATS = $(sort  owl obo json owl)
 FORMATS_INCL_TSV = $(sort $(FORMATS) tsv)
-RELEASE_ARTEFACTS = $(sort $(ONT)-base $(ONT)-simple $(ONT)-full $(ONT)-base $(ONT)-full)
+RELEASE_ARTEFACTS = $(sort $(ONT)-base $(ONT)-simple $(ONT)-full zfa-zfin $(ONT)-base $(ONT)-full)
 
 # ----------------------------------------
 # Top-level targets
@@ -365,19 +365,25 @@ $(ONT)-full.json: $(ONT)-full.owl
 	$(ROBOT) annotate --input $< --ontology-iri $(ONTBASE)/$@ $(ANNOTATE_ONTOLOGY_VERSION) \
 		convert --check false -f json -o $@.tmp.json &&\
 	jq -S 'walk(if type == "array" then sort else . end)' $@.tmp.json > $@ && rm $@.tmp.json
+zfa-zfin.obo: zfa-zfin.owl
+	$(ROBOT) convert --input $< --check false -f obo $(OBO_FORMAT_OPTIONS) -o $@.tmp.obo && grep -v ^owl-axioms $@.tmp.obo > $@ && rm $@.tmp.obo
+zfa-zfin.json: zfa-zfin.owl
+	$(ROBOT) annotate --input $< --ontology-iri $(ONTBASE)/$@ $(ANNOTATE_ONTOLOGY_VERSION) \
+		convert --check false -f json -o $@.tmp.json &&\
+	jq -S 'walk(if type == "array" then sort else . end)' $@.tmp.json > $@ && rm $@.tmp.json
 # We always want a base - even if it is not explicitly configured..
 # We always want a full release - even if it is not explicitly configured..
 # ----------------------------------------
 # Release artefacts: main release artefacts
 # ----------------------------------------
 
-$(ONT).owl: $(ONT)-full.owl
+$(ONT).owl: $(ONT)-zfin.owl
 	$(ROBOT) annotate --input $< --ontology-iri $(URIBASE)/$@ $(ANNOTATE_ONTOLOGY_VERSION) \
 		convert -o $@.tmp.owl && mv $@.tmp.owl $@
 
 $(ONT).obo: $(ONT).owl
 	$(ROBOT) convert --input $< --check false -f obo $(OBO_FORMAT_OPTIONS) -o $@.tmp.obo && grep -v ^owl-axioms $@.tmp.obo > $@ && rm $@.tmp.obo
-$(ONT).json: $(ONT)-full.owl
+$(ONT).json: $(ONT)-zfin.owl
 	$(ROBOT) annotate --input $< --ontology-iri $(URIBASE)/$@ $(ANNOTATE_ONTOLOGY_VERSION) \
 		convert --check false -f json -o $@.tmp.json && \
 	jq -S 'walk(if type == "array" then sort else . end)' $@.tmp.json > $@ && rm $@.tmp.json
@@ -429,6 +435,9 @@ $(ONT)-simple.owl: $(SRC) $(OTHER_SRC) $(SIMPLESEED)
 		reduce -r ELK \
 		query --update ../sparql/inject-subset-declaration.ru \
 		$(SHARED_ROBOT_COMMANDS) annotate --ontology-iri $(ONTBASE)/$@ $(ANNOTATE_ONTOLOGY_VERSION) --output $@.tmp.owl && mv $@.tmp.owl $@
+
+zfa-zfin.owl:
+	echo "ERROR: You have configured a custom release artefact ($@); this release artefact needs to be define in zfa.Makefile!" && false
 # ----------------------------------------
 # Debugging Tools
 # ----------------------------------------

--- a/src/ontology/zfa-odk.yaml
+++ b/src/ontology/zfa-odk.yaml
@@ -6,6 +6,7 @@ report_fail_on: none
 namespaces: 
   - http://purl.obolibrary.org/obo/ZFA_
   - http://purl.obolibrary.org/obo/zfa.owl
+  - http://purl.obolibrary.org/obo/ZFS_
 export_formats:
   - owl
   - obo
@@ -14,7 +15,8 @@ release_artefacts:
   - base
   - simple
   - full
-primary_release: full
+  - custom-zfa-zfin
+primary_release: zfin
 import_group:
   products:
     - id: ro

--- a/src/ontology/zfa.Makefile
+++ b/src/ontology/zfa.Makefile
@@ -3,3 +3,10 @@
 ## If you need to customize your Makefile, make
 ## changes here rather than in the main Makefile
 
+# zfa-zfin does not use REDUCE to avoid stripping out redundant stage 
+# information on terms
+zfa-zfin.owl: $(SRC) $(OTHER_SRC)
+	$(ROBOT) merge --input $< \
+		reason --reasoner ELK --equivalent-classes-allowed asserted-only --exclude-tautologies structural \
+		relax \
+		$(SHARED_ROBOT_COMMANDS) annotate --ontology-iri $(ONTBASE)/$@ $(ANNOTATE_ONTOLOGY_VERSION) --output $@.tmp.owl && mv $@.tmp.owl $@

--- a/src/sparql/equivalent-classes-violation.sparql
+++ b/src/sparql/equivalent-classes-violation.sparql
@@ -1,6 +1,6 @@
-PREFIX oio: <http://www.geneontology.org/formats/oboInOwl#>
-PREFIX owl: <http://www.w3.org/2002/07/owl#>
-PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix oio: <http://www.geneontology.org/formats/oboInOwl#>
+prefix owl: <http://www.w3.org/2002/07/owl#>
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
 SELECT ?baseClass ?baseLabel ?equivalentClass ?equivalentLabel WHERE 
 {
@@ -10,5 +10,5 @@ SELECT ?baseClass ?baseLabel ?equivalentClass ?equivalentLabel WHERE
 
   FILTER (!isBlank(?baseClass)) .
   FILTER (!isBlank(?equivalentClass))
-}
 
+}

--- a/src/sparql/owldef-self-reference-violation.sparql
+++ b/src/sparql/owldef-self-reference-violation.sparql
@@ -1,11 +1,11 @@
-PREFIX rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-PREFIX oio: <http://www.geneontology.org/formats/oboInOwl#>
-PREFIX owl: <http://www.w3.org/2002/07/owl#>
-PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix oio: <http://www.geneontology.org/formats/oboInOwl#>
+prefix owl: <http://www.w3.org/2002/07/owl#>
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
-SELECT ?c WHERE {
+SELECT ?c
+WHERE {
   { ?c owl:equivalentClass [ owl:intersectionOf [ rdf:rest*/rdf:first ?c ] ] }
     UNION
   { ?c owl:equivalentClass [ owl:intersectionOf [ rdf:rest*/rdf:first [ owl:someValuesFrom ?c ] ] ] }
 }
-

--- a/src/sparql/zfa_terms.sparql
+++ b/src/sparql/zfa_terms.sparql
@@ -3,5 +3,5 @@ WHERE {
   { ?s1 ?p1 ?term . }
   UNION
   { ?term ?p2 ?o2 . }
-  FILTER(isIRI(?term) && (regex(str(?term), UCASE("zfa_")) || regex(str(?term), "http://purl.obolibrary.org/obo/ZFA_") || regex(str(?term), "http://purl.obolibrary.org/obo/zfa.owl")))
+  FILTER(isIRI(?term) && (regex(str(?term), UCASE("zfa_")) || regex(str(?term), "http://purl.obolibrary.org/obo/ZFA_") || regex(str(?term), "http://purl.obolibrary.org/obo/zfa.owl") || regex(str(?term), "http://purl.obolibrary.org/obo/ZFS_")))
 }


### PR DESCRIPTION
Previously, stage and partonomy information on ZFA terms was removed when it was logically redundant, i.e. a parent term already related the same information.

Given the prevalence of structural tools, @ybradford convinced us to not only add a non-redundant release (zfa-zfin.owl), but also make it the default (zfa.owl).

This PR takes care of that. @ybradford, you can merge this is in and run a release!