### PR TITLE
Update zfa-edit.obo

### DIFF
--- a/zfa-edit.obo
+++ b/zfa-edit.obo
@@ -15,6 +15,8 @@ ontology: zfa
 property_value: http://purl.org/dc/elements/1.1/description "ZFA description (add something). adding more" xsd:string
 property_value: http://purl.org/dc/elements/1.1/title "Zebrafish Anatomy Ontology (ZFA)" xsd:string
 property_value: http://purl.org/dc/terms/license https://creativecommons.org/licenses/by/3.0/
+property_value: IAO:0000700 ZFS:0100000
+property_value: IAO:0000700 ZFA:0100000
 
 [Term]
 id: ZFA:0000000


### PR DESCRIPTION
Related to https://github.com/OBOFoundry/OBOFoundry.github.io/issues/2149

# What this Does
Applies the annotation property [has ontology root term (IAO:0000700)](http://purl.obolibrary.org/obo/IAO_0000700) to ZFA:0100000

# Why this is helpful
the Ontology Lookup Service uses this to help better display ontologies
if the term mentioned above is ever aligned with an upper ontology like BFO, it still will be the thing shown on OLS as the "root"
this will be generally useful for things like alignment with COB since it makes it easier to figure out where the work will be

cc @matentzn and @cthoyt